### PR TITLE
Miscellaneous code cleanups

### DIFF
--- a/cli/scp_cli.c
+++ b/cli/scp_cli.c
@@ -89,7 +89,7 @@ static int send_msg_type_scp_open_snd(int s, char *src, char *remote_dir)
     msg.type = msg_type_scp_open_snd;
     msg.len = sprintf(msg.buf, "%s %s", src, complete_dst) + 1;
     if (mdl_queue_write_msg(s, &msg))
-      KERR("%d", msg.len);
+      KERR("%ld", msg.len);
     }
   return result;
 }
@@ -106,7 +106,7 @@ static int send_msg_type_scp_open_rcv(int s, char *src, char *local_dir)
     msg.type = msg_type_scp_open_rcv;
     msg.len = sprintf(msg.buf, "%s %s", src, complete_dst) + 1;
     if (mdl_queue_write_msg(s, &msg))
-      KERR("%d", msg.len);
+      KERR("%ld", msg.len);
     result = 0;
     }
   return result;
@@ -120,7 +120,7 @@ static void send_scp_data_end(int sock_fd)
   msg.type = msg_type_scp_data_end;
   msg.len = 0;
   if (mdl_queue_write_msg(sock_fd, &msg))
-    KERR("%d", msg.len);
+    KERR("%ld", msg.len);
 }
 /*--------------------------------------------------------------------------*/
 
@@ -131,7 +131,7 @@ static void send_scp_data_begin(int sock_fd)
   msg.type = msg_type_scp_data_begin;
   msg.len = 0;
   if (mdl_queue_write_msg(sock_fd, &msg))
-    KERR("%d", msg.len);
+    KERR("%ld", msg.len);
 }
 /*--------------------------------------------------------------------------*/
 
@@ -148,7 +148,7 @@ static int send_scp_data(int sock_fd)
   msg.type = msg_type_scp_data;
   msg.len = len;
   if (mdl_queue_write_msg(sock_fd, &msg))
-    KERR("%d", msg.len);
+    KERR("%ld", msg.len);
   return result;
 }
 /*--------------------------------------------------------------------------*/
@@ -164,7 +164,7 @@ void recv_scp_data_end(int sock_fd)
   msg.type = msg_type_scp_data_end_ack;
   msg.len = 0;
   if (mdl_queue_write_msg(sock_fd, &msg))
-    KERR("%d", msg.len);
+    KERR("%ld", msg.len);
 }
 /*--------------------------------------------------------------------------*/
 
@@ -176,7 +176,7 @@ void recv_scp_data(t_msg *msg)
     KOUT(" ");
   len = write(g_scp_fd, msg->buf, msg->len);
   if ((len < 0) || (len != msg->len))
-    KOUT("%d %d %d", len, msg->len, errno);
+    KOUT("%d %ld %d", len, msg->len, errno);
 }
 /*--------------------------------------------------------------------------*/
 
@@ -239,7 +239,7 @@ static int rx_scp_msg_cb(void *ptr, int sock_fd, t_msg *msg)
       exit(0);
       break;
     default:
-      KOUT("%d", msg->type);
+      KOUT("%ld", msg->type);
     }
   return 0;
 }

--- a/cli/vsock_cli.c
+++ b/cli/vsock_cli.c
@@ -42,7 +42,6 @@ static struct termios g_orig_term;
 static struct termios g_cur_term;
 static int g_win_chg_write_fd;
 static int g_x11_ok;
-static char g_sock_path[MAX_PATH_LEN];
 static int g_is_snd;
 static int g_is_rcv;
 
@@ -224,7 +223,7 @@ static void rx_err_cb (void *ptr, char *err)
 static int rx_msg_cb(void *ptr, int sock_fd, t_msg *msg)
 {
   (void) ptr;
-  int len, type, disp_idx, conn_idx;
+  int type, disp_idx, conn_idx;
   type = msg->type & 0xFFFF;
   disp_idx = (msg->type >> 24) & 0x00FF;
   conn_idx = (msg->type >> 16) & 0x00FF;
@@ -458,7 +457,6 @@ static int get_params(int ac, char **av, char **cmd, char **src, char **dst)
 /****************************************************************************/
 int main(int argc, char **argv)
 {
-  char unix_sock_path[MAX_PATH_LEN];
   char *cmd, *src, *dst;
   g_is_snd = 0;
   g_is_rcv = 0;

--- a/cli/vsock_cli.c
+++ b/cli/vsock_cli.c
@@ -68,7 +68,8 @@ static void win_size_chg(int sig)
 {
   char buf[1];
   buf[0] = 'w';
-  write(g_win_chg_write_fd, buf, 1);
+  if (write(g_win_chg_write_fd, buf, 1) == -1)
+    KERR("Unable to write to g_win_chg_write_fd: %s", strerror(errno));
 }
 /*--------------------------------------------------------------------------*/
 
@@ -204,9 +205,9 @@ static int connect_vsock(int cid, int port)
 /****************************************************************************/
 static void action_win_chg(int sock_fd, int win_chg_read_fd)
 {
-  int len;
   char buf[16];
-  len = read(win_chg_read_fd, buf, sizeof(buf));
+  if (read(win_chg_read_fd, buf, sizeof(buf)) == -1)
+    KERR("Could not read from win_chg_read_fd: %s", strerror(errno));
   send_msg_type_win_size(sock_fd);
 }
 /*--------------------------------------------------------------------------*/

--- a/cli/vsock_cli.c
+++ b/cli/vsock_cli.c
@@ -88,7 +88,7 @@ static void send_msg_type_open_pty(int s, char *cmd)
     msg.len = 0;
     }
   if (mdl_queue_write_msg(s, &msg))
-    KERR("%d", msg.len);
+    KERR("%ld", msg.len);
 }
 /*--------------------------------------------------------------------------*/
 
@@ -100,7 +100,7 @@ static void send_msg_type_win_size(int s)
   msg.len = sizeof(struct winsize);
   ioctl(0, TIOCGWINSZ, msg.buf);
   if (mdl_queue_write_msg(s, &msg))
-    KERR("%d", msg.len);
+    KERR("%ld", msg.len);
 }
 /*--------------------------------------------------------------------------*/
 
@@ -233,7 +233,7 @@ static int rx_msg_cb(void *ptr, int sock_fd, t_msg *msg)
     {
     case msg_type_data_cli:
       if (mdl_queue_write_raw(1, msg->buf, msg->len))
-        KERR("%d", msg->len);
+        KERR("%ld", msg->len);
       break;
     case msg_type_end_cli:
       mdl_write(1);
@@ -255,7 +255,7 @@ static int rx_msg_cb(void *ptr, int sock_fd, t_msg *msg)
       x11_disconnect(disp_idx, conn_idx);
       break;
     default:
-      KOUT("%d", msg->type & 0xFFFF);
+      KOUT("%ld", msg->type & 0xFFFF);
     }
   return 0;
 }
@@ -274,7 +274,7 @@ static void action_input_rx(int sock_fd)
     msg.type = msg_type_data_pty;
     msg.len = len;
     if (mdl_queue_write_msg(sock_fd, &msg))
-      KERR("%d", msg.len);
+      KERR("%ld", msg.len);
     }
 }
 /*--------------------------------------------------------------------------*/
@@ -391,7 +391,7 @@ static void main_usock(char *unix_sock_path,
   if (sock_fd < 0)
     KOUT(" %s: %s\n", unix_sock_path, strerror(errno));
   if (cmd && (strlen(cmd) >= MAX_MSG_LEN))
-    KOUT("%d %s", strlen(cmd), cmd);
+    KOUT("%zd %s", strlen(cmd), cmd);
   loop_cli(sock_fd, cmd, src, dst);
 }
 /*--------------------------------------------------------------------------*/
@@ -405,7 +405,7 @@ static void main_vsock(char *cid, char *port,
   vsock_port = mdl_parse_val(port);
   sock_fd = connect_vsock(vsock_cid, vsock_port);
   if (cmd && (strlen(cmd) >= MAX_MSG_LEN))
-    KOUT("%d %s", strlen(cmd), cmd);
+    KOUT("%zd %s", strlen(cmd), cmd);
   loop_cli(sock_fd, cmd, src, dst);
 }
 /*--------------------------------------------------------------------------*/
@@ -420,7 +420,7 @@ static void main_isock(char *ip, char *port,
   if (sock_fd < 0)
     KOUT(" %s %s %s\n", ip, port, strerror(errno));
   if (cmd && (strlen(cmd) >= MAX_MSG_LEN))
-    KOUT("%d %s", strlen(cmd), cmd);
+    KOUT("%zd %s", strlen(cmd), cmd);
   loop_cli(sock_fd, cmd, src, dst);
 }
 /*--------------------------------------------------------------------------*/

--- a/cli/x11_fwd.c
+++ b/cli/x11_fwd.c
@@ -146,7 +146,7 @@ static int get_xauth_magic(char *display, char *err)
           {
           ptr += strlen("MIT-MAGIC-COOKIE-1");
           ptr += strspn(ptr, " \t");
-          if (!strlen(ptr) > 1)
+          if (strlen(ptr) < 1)
             snprintf(err, MAX_PATH_LEN-1, "%s, MIT-MAGIC strlen1", buf);
           else
             {
@@ -156,7 +156,7 @@ static int get_xauth_magic(char *display, char *err)
             end = strchr(ptr, '\n');
             if (end) 
               *end = 0;
-            if (!strlen(ptr) > 1)
+            if (strlen(ptr) < 1)
               snprintf(err, MAX_PATH_LEN-1, "%s, MIT-MAGIC strlen2", buf);
             else
               {

--- a/cli/x11_fwd.c
+++ b/cli/x11_fwd.c
@@ -48,7 +48,7 @@ static void send_msg_type_x11_init(int s)
   msg.type = msg_type_x11_init;
   msg.len = 0;
   if (mdl_queue_write_msg(s, &msg))
-    KERR("%d", msg.len);
+    KERR("%ld", msg.len);
 }
 /*--------------------------------------------------------------------------*/
 
@@ -62,7 +62,7 @@ static void send_msg_type_x11_connect_ack(int s, int disp_idx,
               (msg_type_x11_connect_ack & 0xFFFF);
   msg.len = sprintf(msg.buf, "%s", txt) + 1;
   if (mdl_queue_write_msg(s, &msg))
-    KERR("%d", msg.len);
+    KERR("%ld", msg.len);
 }
 /*--------------------------------------------------------------------------*/
 
@@ -105,7 +105,7 @@ static int x11_action_fd(int disp_idx, int conn_idx, int x11_fd, int sock_fd)
                 (msg_type_x11_data & 0xFFFF);
     msg.len = len;
     if (mdl_queue_write_msg(sock_fd, &msg))
-      KERR("%d", msg.len);
+      KERR("%ld", msg.len);
     else
       result = 0;
     }

--- a/cli/x11_fwd.c
+++ b/cli/x11_fwd.c
@@ -228,7 +228,6 @@ void x11_fd_isset(fd_set *readfds)
 /****************************************************************************/
 void x11_disconnect(int disp_idx, int conn_idx)
 {
-  int fd = -1;
   if ((disp_idx <= 0) || (disp_idx >= MAX_DISPLAY_X11))
     KOUT("%d %d", disp_idx, conn_idx);
   if ((conn_idx <= 0) || (conn_idx >= MAX_IDX_X11))
@@ -301,7 +300,7 @@ void x11_connect(int disp_idx, int conn_idx, int sock_fd)
 /****************************************************************************/
 void x11_init(int sock_fd)
 {
-  int fd, val, result = -1;
+  int fd, val;
   char err[MAX_PATH_LEN];
   char *display = getenv("DISPLAY");
   g_x11_port = 0;

--- a/libmdl/mdl.c
+++ b/libmdl/mdl.c
@@ -188,15 +188,15 @@ static void do_cb(t_mdl *mdl, void *ptr, int fd,
   if (rxoffst >= g_msg_header_len)
     {
     if (msg->cafe != 0xCAFEDECA)
-      KOUT("header id is %X", msg->cafe);
+      KOUT("header id is %lX", msg->cafe);
     if ((msg->len < 0) || (msg->len > MAX_MSG_LEN))
-      KOUT("header len: %d", msg->len); 
+      KOUT("header len: %ld", msg->len); 
     if (rxoffst >= msg->len + g_msg_header_len)
       {
       do
         {
         if (msg->cafe != 0xCAFEDECA)
-          KOUT("header id is %X", msg->cafe);
+          KOUT("header id is %lX", msg->cafe);
         if (rx_cb(ptr, fd, msg))
           return;
         done = msg->len + g_msg_header_len;
@@ -210,9 +210,9 @@ static void do_cb(t_mdl *mdl, void *ptr, int fd,
       if (rxoffst >= g_msg_header_len)
         {
         if (msg->cafe != 0xCAFEDECA)
-          KOUT("header id is %X", msg->cafe);
+          KOUT("header id is %lX", msg->cafe);
         if ((msg->len < 0) || (msg->len > MAX_MSG_LEN))
-          KOUT("header len: %d", msg->len); 
+          KOUT("header len: %ld", msg->len); 
         }
       tmp = (char *) malloc(rxoffst);
       memcpy(tmp, msg, rxoffst);
@@ -222,9 +222,9 @@ static void do_cb(t_mdl *mdl, void *ptr, int fd,
         {
         msg = (t_msg *) mdl->bufrx;
         if (msg->cafe != 0xCAFEDECA)
-          KOUT("header id is %X", msg->cafe);
+          KOUT("header id is %lX", msg->cafe);
         if ((msg->len < 0) || (msg->len > MAX_MSG_LEN))
-          KOUT("header len: %d", msg->len);
+          KOUT("header len: %ld", msg->len);
         }
       mdl->rxoffst = rxoffst;
       }

--- a/libmdl/mdl.c
+++ b/libmdl/mdl.c
@@ -238,7 +238,7 @@ static void do_cb(t_mdl *mdl, void *ptr, int fd,
 void mdl_read(void *ptr, int s, t_rx_msg_cb rx_cb, t_rx_err_cb err_cb)
 {
   char err[MAX_PATH_LEN];
-  int len, wlen, max_to_read;
+  int len, max_to_read;
   t_mdl *mdl = g_mdl[s];
   if (!mdl) 
     err_cb(ptr, "Context mdl not found");

--- a/srv/scp_srv.c
+++ b/srv/scp_srv.c
@@ -92,6 +92,7 @@ static void scp_cli_snd(int *fd, char *src, char *complete_dst, char *resp)
 static void scp_cli_rcv(int *fd, char *src, char *complete_dst, char *resp)
 { 
   if (!scp_rx_open_rcv(src, complete_dst, resp))
+    {
     *fd = open(src, O_RDONLY);
     if (*fd == -1)
       {
@@ -99,6 +100,7 @@ static void scp_cli_rcv(int *fd, char *src, char *complete_dst, char *resp)
       resp[1] = 'O';
       KERR("%s %d", src, errno);
       }
+    }
 }
 /*--------------------------------------------------------------------------*/
 
@@ -198,6 +200,7 @@ int recv_scp_open(int type, int sock_fd, int *cli_scp_fd, char *buf)
       send_resp_cli(msg_type_scp_ready_to_snd, sock_fd, resp);
       }
     }
+  return result;
 }
 /*--------------------------------------------------------------------------*/
 

--- a/srv/scp_srv.c
+++ b/srv/scp_srv.c
@@ -58,7 +58,6 @@ static int scp_rx_open_snd(char *src, char *complete_dst, char *resp)
 static int scp_rx_open_rcv(char *src, char *complete_dst, char *resp)
 {
   struct stat sb;
-  char *bn;
   int result = -1;
   memset(resp, 0, MAX_PATH_LEN);
   if (stat(src, &sb) == -1)

--- a/srv/scp_srv.c
+++ b/srv/scp_srv.c
@@ -110,7 +110,7 @@ static void send_resp_cli(int type, int sock_fd, char *resp)
   msg.type = type;
   msg.len = sprintf(msg.buf, "%s", resp) + 1;
   if (mdl_queue_write_msg(sock_fd, &msg))
-    KERR("%d", msg.len);
+    KERR("%ld", msg.len);
 }
 /*--------------------------------------------------------------------------*/
 
@@ -122,7 +122,7 @@ static void send_scp_data_end(int sock_fd)
   msg.type = msg_type_scp_data_end;
   msg.len = 0;
   if (mdl_queue_write_msg(sock_fd, &msg))
-    KERR("%d", msg.len);
+    KERR("%ld", msg.len);
 }
 /*--------------------------------------------------------------------------*/
 
@@ -139,7 +139,7 @@ static int send_scp_data(int scp_fd, int sock_fd)
   msg.type = msg_type_scp_data;
   msg.len = len;
   if (mdl_queue_write_msg(sock_fd, &msg))
-    KERR("%d", msg.len);
+    KERR("%ld", msg.len);
   return result;
 }
 /*--------------------------------------------------------------------------*/
@@ -155,7 +155,7 @@ void recv_scp_data_end(int scp_fd, int sock_fd)
   msg.type = msg_type_scp_data_end_ack;
   msg.len = 0;
   if (mdl_queue_write_msg(sock_fd, &msg))
-    KERR("%d", msg.len);
+    KERR("%ld", msg.len);
 }
 /*--------------------------------------------------------------------------*/
 
@@ -169,7 +169,7 @@ void recv_scp_data(int scp_fd, t_msg *msg)
     {
     len = write(scp_fd, msg->buf, msg->len);
     if ((len < 0) || (len != msg->len))
-      KERR("%d %d %d", len, msg->len, errno);
+      KERR("%d %ld %d", len, msg->len, errno);
     }
 }
 /*--------------------------------------------------------------------------*/

--- a/srv/vsock_srv.c
+++ b/srv/vsock_srv.c
@@ -530,7 +530,7 @@ static void prepare_fd_set(int listen_sock_fd, int sig_read_fd,
 static void server_loop(int listen_sock_fd, int sig_read_fd)
 {
   int max_fd;
-  t_cli *next, *cur;
+  t_cli *next = NULL, *cur;
   fd_set readfds, writefds;
   cur = g_cli_head;
   while(cur)
@@ -588,7 +588,8 @@ static void server_loop(int listen_sock_fd, int sig_read_fd)
 static void vsock_srv(int listen_sock_fd)
 {
   int pipe_fd[2];
-  daemon(0,0);
+  if (daemon(0, 0) == -1)
+    KOUT("daemon(): %s", strerror(errno));
   signal(SIGPIPE, SIG_IGN);
   if (signal(SIGHUP, SIG_IGN))
     KERR("%d", errno);

--- a/srv/vsock_srv.c
+++ b/srv/vsock_srv.c
@@ -331,7 +331,7 @@ static void send_msg_type_end(int s, char status)
   msg.len = 1;
   msg.buf[0] = status;
   if (mdl_queue_write_msg(s, &msg))
-    KERR("%d", msg.len);
+    KERR("%ld", msg.len);
 }
 /*--------------------------------------------------------------------------*/
 
@@ -352,7 +352,7 @@ static int rx_msg_cb(void *ptr, int sock_fd, t_msg *msg)
       if (cli->pty_master_fd == -1)
         KOUT(" ");
       else if (mdl_queue_write_raw(cli->pty_master_fd, msg->buf, msg->len))
-        KERR("%d", msg->len);
+        KERR("%ld", msg->len);
     break;
 
     case msg_type_open_bash :
@@ -418,7 +418,7 @@ static int rx_msg_cb(void *ptr, int sock_fd, t_msg *msg)
       break;
 
     default :
-      KOUT("%d", msg->type);
+      KOUT("%ld", msg->type);
       }
   return result;
 }

--- a/srv/vsock_srv.c
+++ b/srv/vsock_srv.c
@@ -609,20 +609,6 @@ static void vsock_srv(int listen_sock_fd)
 /*--------------------------------------------------------------------------*/
 
 /****************************************************************************/
-static int parse_port(const char *port_str)
-{
-  int result = -1;
-  char *end = NULL;
-  long port = strtol(port_str, &end, 10);
-  if (port_str != end && *end == '\0')
-    result = (int) port;
-  else
-    KOUT("%s", port_str);
-  return result;
-}
-/*--------------------------------------------------------------------------*/
-
-/****************************************************************************/
 static void usage(char *name)
 {
   printf("\n%s <vsock_port>\n", name);

--- a/srv/x11_fwd.c
+++ b/srv/x11_fwd.c
@@ -201,7 +201,7 @@ static int prepare_next_conn_idx(t_display_x11 *disp)
 /****************************************************************************/
 static void x11_listen_action(t_display_x11 *disp)
 {
-  int fd, conn_idx;
+  int fd;
   fd = accept(disp->x11_listen_fd, NULL, NULL);
   if (fd < 0)
     KERR("%s", strerror(errno));

--- a/srv/x11_fwd.c
+++ b/srv/x11_fwd.c
@@ -154,7 +154,7 @@ static void send_msg_type_x11_connect(int s, int disp_idx, int conn_idx)
               (msg_type_x11_connect & 0xFFFF);
   msg.len = 0;
   if (mdl_queue_write_msg(s, &msg))
-    KERR("%d", msg.len);
+    KERR("%ld", msg.len);
 }
 /*--------------------------------------------------------------------------*/
 
@@ -165,7 +165,7 @@ static void send_msg_type_x11_init(int s, char *txt)
   msg.type = msg_type_x11_init;
   msg.len = sprintf(msg.buf, "%s", txt) + 1;
   if (mdl_queue_write_msg(s, &msg))
-    KERR("%d", msg.len);
+    KERR("%ld", msg.len);
 }
 /*--------------------------------------------------------------------------*/
 
@@ -178,7 +178,7 @@ static void disconnect_conn_idx(t_display_x11 *disp, int conn_idx)
               (msg_type_x11_disconnect & 0xFFFF);
   msg.len = 0;
   if (mdl_queue_write_msg(disp->sock_fd, &msg))
-    KERR("%d", msg.len);
+    KERR("%ld", msg.len);
   close(disp->conn[conn_idx]->x11_fd);
   free_pool_idx(disp, conn_idx);
 }
@@ -239,7 +239,7 @@ static int x11_action_fd(int disp_idx, int conn_idx, int x11_fd, int sock_fd)
                 (msg_type_x11_data & 0xFFFF);
     msg.len = len;
     if (mdl_queue_write_msg(sock_fd, &msg))
-      KERR("%d", msg.len);
+      KERR("%ld", msg.len);
     else
       result = 0;
     }


### PR DESCRIPTION
This should fix all the compiler errors that were reported when compiling with `-Wall`.

There are some occasions (like dc58a28def9d8cab9a5f4bccdee160927a6d14a6) where I wasn't sure what the author has intended, so I hope I did the correct thing there.